### PR TITLE
Add annotation "Symbol" as "remoteBuild"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <jmockit.version>1.5</jmockit.version>
     <junit.version>4.11</junit.version>
     <rabbitmq.consumer.version>2.5</rabbitmq.consumer.version>
+    <structs.version>1.10</structs.version>
     <commons.lang3.version>3.6</commons.lang3.version>
   </properties>
 
@@ -67,6 +68,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>rabbitmq-consumer</artifactId>
       <version>${rabbitmq.consumer.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>${structs.version}</version>
     </dependency>
     <dependency>
         <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/rabbitmqbuildtrigger/RemoteBuildTrigger.java
@@ -28,6 +28,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.rabbitmqconsumer.extensions.MessageQueueListener;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -198,7 +199,7 @@ public class RemoteBuildTrigger<T extends Job<?, ?> & ParameterizedJobMixIn.Para
      *
      * @author rinrinne a.k.a. rin_ne
      */
-    @Extension
+    @Extension @Symbol("remoteBuild")
     public static class DescriptorImpl extends TriggerDescriptor {
 
         @Override


### PR DESCRIPTION
This patch adds annotation "Symbol" to TriggerDescriptor.
This has ability to use this in declarative pipeline script
as "remoteBuild" trigger. e.g.

```
pipeline {
  triggers {
    remoteBuild('<TOKEN>')
  }
}
```